### PR TITLE
Make g_logger's life time longer than thread pool

### DIFF
--- a/include/thread_pool.h
+++ b/include/thread_pool.h
@@ -15,6 +15,7 @@
 #include <boost/function.hpp>
 #include "mutex.h"
 #include "timer.h"
+#include "logging.h"
 
 namespace baidu {
 namespace common {
@@ -46,6 +47,11 @@ public:
         if (tids_.size()) {
             return false;
         }
+        /// It's a ticky here. Call LOG just to make sure g_logger
+        /// is uninitialized before thread pool, so g_logger is sure
+        /// to be deconstructed after thread pool. So when destroy
+        /// this thread pool, threads can safely write on-going logs out.
+        LOG(INFO, "Init thread pool");
         stop_ = false;
         for (int i = 0; i < threads_num_; i++) {
             pthread_t tid;


### PR DESCRIPTION
AsyncLogger g_logger是一个全局对象，当thread pool也为全局对象时，由于这两个对象分布在不同的编译单元，所以其构造函数执行的顺序是无法确定的。若thread pool先于g_logger构造，则main函数执行完时，g_logger将先于thread_pool析构，再对thread_pool进行析构时，有可能部分线程需要写log，这样会造成未定义的行为。
将g_logger变为函数内部的局部静态变量，并在thread_pool构造时写一条log，这样可以保证g_logger先于thread_pool被构造出来，也就可以保证g_logger将晚于thread_pool被析构，程序退出时，thread_pool线程写log不会出错。
不过static变量没考虑多线程的问题。C++11里可以保证这是没问题的，C++03不能保证。但是个人感觉在thread_pool的初始化阶段不会有其它线程写log，于是这里没做特殊处理。