### PR TITLE
fix unused variables WARNING

### DIFF
--- a/include/mutex.h
+++ b/include/mutex.h
@@ -64,6 +64,8 @@ private:
             lock_time_ = timer::get_micros();
         }
         #endif
+        (void)msg;
+        (void)msg_threshold;
         owner_ = pthread_self();
     }
     void BeforeUnlock() {


### PR DESCRIPTION
如果项目依赖了common库，并且有-Wall -Werror选项的时候，会编译不过。