### PR TITLE
Use shared_ptr/weak_ptr to manage g_logger's lifetime

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -8,6 +8,8 @@
 
 #include <assert.h>
 #include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
 #include <queue>
 #include <stdarg.h>
 #include <stdint.h>
@@ -98,7 +100,7 @@ private:
     std::queue<std::pair<int, std::string*> > buffer_queue_;
 };
 
-AsyncLogger g_logger;
+boost::shared_ptr<AsyncLogger> g_logger(new AsyncLogger);
 
 bool SetWarningFile(const char* path, bool append) {
     const char* mode = append ? "ab" : "wb";
@@ -131,6 +133,11 @@ void Logv(int log_level, const char* format, va_list ap) {
     static __thread uint64_t thread_id = 0;
     if (thread_id == 0) {
         thread_id = syscall(__NR_gettid);
+    }
+    static __thread boost::weak_ptr<AsyncLogger> wk_logger = g_logger;
+    boost::shared_ptr<AsyncLogger> logger = wk_logger.lock();
+    if (!logger) {
+        return;
     }
 
     // We try twice: the first time with a fixed-size stack allocated buffer,
@@ -193,9 +200,9 @@ void Logv(int log_level, const char* format, va_list ap) {
         //    fwrite(base, 1, p - base, g_warning_file);
         //    fflush(g_warning_file);
         //}
-        g_logger.WriteLog(log_level, base, p - base);
+        logger->WriteLog(log_level, base, p - base);
         if (log_level == FATAL) {
-            g_logger.Flush();
+            logger->Flush();
         }
         if (base != buffer) {
             delete[] base;


### PR DESCRIPTION
不知道性能会不会有较大影响，或者写个程序测一下？